### PR TITLE
added openpose as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/openpose"]
+	path = src/openpose
+	url = https://github.com/nivlekp/openpose


### PR DESCRIPTION
For a trial, I'm adding openpose as a submodule inside the `src` directory.
Hope this works.
Once it is merged, to include the submodule inside your locally cloned repo, you might have to run `git submodule update --init --recursive` after `git pull`.